### PR TITLE
Adding some fixes to MMT code

### DIFF
--- a/src/DumpTS.cpp
+++ b/src/DumpTS.cpp
@@ -226,9 +226,16 @@ bool VerifyCommandLine()
 	if (g_params.find("pid") != g_params.end())
 	{
 		long long pid = ConvertToLongLong(g_params["pid"]);
-		if (!(pid >= 0 && pid <= 0x1FFF))
+		uint16_t max_pid = 0x1fff;
+
+		// MMT can have PIDs > 0x1FFF
+		auto iter = g_params.find("srcfmt");
+		if (iter->second.compare("mmt") == 0)
+			max_pid = 0xffff;
+
+		if (!(pid >= 0 && pid <= max_pid))
 		{
-			printf("The specified PID: %s is invalid, please make sure it is between 0 to 0x1FFF inclusive.\n", g_params["pid"].c_str());
+			printf("The specified PID: %s is invalid, please make sure it is between 0 to 0x%04x inclusive.\n", g_params["pid"].c_str(), max_pid);
 			return false;
 		}
 	}

--- a/src/MMT.h
+++ b/src/MMT.h
@@ -1814,6 +1814,7 @@ namespace MMT
 				if (left_bits < ((uint64_t)MPT_descriptors_length << 3))
 					return RET_CODE_BOX_TOO_SMALL;
 
+				MPT_descriptors_bytes.resize(MPT_descriptors_length);
 				bs.Read(&MPT_descriptors_bytes[0], MPT_descriptors_length);
 				left_bits -= (uint64_t)MPT_descriptors_length << 3;
 			}


### PR DESCRIPTION
Heya,

I'm using this to go through some TLV/MMT files and I noticed a bug in the code which skips MPT_descriptors, you do bs.Read(&std::vector) but it's size remains at zero, causing a crash. I guess your sample MMT files didn't have such descriptors, so you didn't notice.

That's commit #1, and second one adds support for --pid to go up to 0xffff (mmt can have PIDs above 1fff since the field is 16bit there). I haven't tested it but it should work.

Anyway, there's some issues still as the 

```DumpTS.exe input.tlv --srcfmt=mmt --output=output.hevc --outputfmt=es --pid=0xa041```

Exits after unsynching with 7F header after few 100kbytes, but that's to be determined with further debugging (my source file should be clean).