### PR TITLE
adding "CID" option

### DIFF
--- a/src/DumpTS.cpp
+++ b/src/DumpTS.cpp
@@ -115,6 +115,7 @@ void ParseCommandLine(int argc, char* argv[])
 	std::string str_arg_prefixes[] = {
 		"output", 
 		"pid", 
+		"CID",
 		"trackid", 
 		"boxtype", 
 		"destpid", 


### PR DESCRIPTION
Some channel need CID=1, or CID=2 to output hevc file for each channel.