### PR TITLE
improved identification and target windows set to 10

### DIFF
--- a/build/vc14/DumpTS.vcxproj
+++ b/build/vc14/DumpTS.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -20,30 +20,30 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{BF77391C-3A97-460E-B1F1-3741C5B3DB78}</ProjectGuid>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/src/PayloadBuf.h
+++ b/src/PayloadBuf.h
@@ -47,6 +47,12 @@ using namespace std;
 #define SESF_TELETEXT_STREAM				0x06
 #define TTML_STREAM							0x06
 
+// extend
+#define PRESENTATION_GRAPHICS				0x90
+#define INTERACTIVE_GRAPHICS				0x91
+#define SUBTITLE							0x92
+#define MPEG1_VIDEO_STREAM					0x01
+
 /*
 	0x0A						Multi-protocol Encapsulation
 	0x0B						DSM-CC U-N Messages
@@ -59,6 +65,7 @@ using namespace std;
 #define DSMCC_TYPE_D						0x0D
 
 #define STREAM_TYPE_NAMEA(st)	(\
+	(st) == MPEG1_VIDEO_STREAM?"MPEG1 Video":(\
 	(st) == MPEG2_VIDEO_STREAM?"MPEG2 Video":(\
 	(st) == MPEG4_AVC_VIDEO_STREAM?"MPEG4 AVC Video":(\
 	(st) == SMPTE_VC1_VIDEO_STREAM?"VC1 Video":(\
@@ -71,7 +78,7 @@ using namespace std;
 	(st) == HDMV_LPCM_AUDIO_STREAM?"HDMV LPCM Audio":(\
 	(st) == DOLBY_AC3_AUDIO_STREAM?"AC3 Audio":(\
 	(st) == DTS_AUDIO_STREAM?"DTS Audio":(\
-	(st) == DOLBY_LOSSLESS_AUDIO_STREAM?"Dolby Lossless Audio":(\
+	(st) == DOLBY_LOSSLESS_AUDIO_STREAM?"Dolby Lossless Audio (TrueHD/Atmos)":(\
 	(st) == DD_PLUS_AUDIO_STREAM?"DD+ Audio":(\
 	(st) == DTS_HD_EXCEPT_XLL_AUDIO_STREAM?"DTS-HD audio":(\
 	(st) == DTS_HD_XLL_AUDIO_STREAM?"DTS-HD Lossless Audio":(\
@@ -80,10 +87,13 @@ using namespace std;
 	(st) == DD_PLUS_SECONDARY_AUDIO_STREAM?"DD+ Secondary Audio":(\
 	(st) == DTS_HD_SECONDARY_AUDIO_STREAM?"DTS LBR Audio":(\
 	(st) == SESF_TELETEXT_STREAM?"Teletext, ARIB subtitle or TTML":(\
+	(st) == PRESENTATION_GRAPHICS?"PGS":(\
+	(st) == INTERACTIVE_GRAPHICS?"IGS":(\
+	(st) == SUBTITLE?"SUB":(\
 	(st) == DSMCC_TYPE_A?"DSM-CC Multi-protocol Encapsulation":(\
 	(st) == DSMCC_TYPE_B?"DSM-CC DSM-CC U-N Messages":(\
 	(st) == DSMCC_TYPE_C?"DSM-CC DSM-CC Stream Descriptors":(\
-	(st) == DSMCC_TYPE_D?"DSM-CC SM-CC Sections":"Unknown")))))))))))))))))))))))))
+	(st) == DSMCC_TYPE_D?"DSM-CC SM-CC Sections":"Unknown")))))))))))))))))))))))))))))
 
 enum MPEG_SYSTEM_TYPE
 {


### PR DESCRIPTION
Added some more `stream types` and changed the target version to win10. Windows 8.1 regular support ended early 2018 (only extended is running till '23)